### PR TITLE
Fixed Crashing Amazon EC2 Instance (#133)

### DIFF
--- a/Assets/World/Track/BuildingManager.cs
+++ b/Assets/World/Track/BuildingManager.cs
@@ -32,7 +32,7 @@ namespace Racerr.World.Track
             buildingMeshFilter = GetComponent<MeshFilter>();
             buildingMeshRenderer = GetComponent<MeshRenderer>();
 
-            originalMesh = buildingMeshFilter.mesh;
+            originalMesh = buildingMeshFilter.sharedMesh;
             originalShader = buildingMeshRenderer.material.shader;
 
             for (int i = 0; i < transform.childCount; i++)
@@ -71,7 +71,7 @@ namespace Racerr.World.Track
         /// <returns>IEnumerator for coroutine.</returns>
         IEnumerator MakeTransparent()
         {
-            buildingMeshFilter.mesh = transparentMesh;
+            buildingMeshFilter.sharedMesh = transparentMesh;
             buildingMeshRenderer.material.shader = transparentShader;
             buildingMeshRenderer.material.SetFloat("_Glossiness", 0);
             activeChildren.ForEach(go => go.SetActive(false));
@@ -84,7 +84,7 @@ namespace Racerr.World.Track
         /// <returns>IEnumerator for coroutine.</returns>
         IEnumerator RevertToOriginal()
         {
-            buildingMeshFilter.mesh = originalMesh;
+            buildingMeshFilter.sharedMesh = originalMesh;
             yield return FadeTransparency(buildingMeshRenderer.material, 1f, 0.1f);
             buildingMeshRenderer.material.shader = originalShader;
             activeChildren.ForEach(go => go.SetActive(true));


### PR DESCRIPTION
Closes #133 
I believe our Amazon EC2 instance was crashing because we ran out of memory. I used the Unity profiler and discovered that Mesh's were constantly being duplicated when generating the track.

You can see why here: https://answers.unity.com/questions/722122/mesh-memory-leak.html
The mesh field is modified by the `BuildingManager` to update the transparent state of the building.

Let's leave the server running for a week to confirm it works before merging this pull request.